### PR TITLE
Move Repomix command in context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         {
           "command": "repomixRunner.run",
           "when": "explorerResourceIsFolder",
-          "group": "navigation@1"
+          "group": "7_modification"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         {
           "command": "repomixRunner.run",
           "when": "explorerResourceIsFolder",
-          "group": "7_modification"
+          "group": "repomix"
         }
       ]
     }


### PR DESCRIPTION
Repomix Run is currently at the top of the context menu. This moves it down, to group '7_modification', which is a better section for this command in my opinion.