### PR TITLE
Feat/add new cli flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the "Repomix Runner" extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.16] - 2025-01-28
+
+### Changed
+
+- Add new supported Repomix config options
+  - output.parsableStyle
+  - output.headerText
+  - output.instructionFilePath
+  - output.includeEmptyDirectories
+  - ignore.useGitignore
+  - tokenCount.encoding
+
 ## [0.0.15] - 2025-01-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "repomix-runner",
       "version": "0.0.15",
       "dependencies": {
+        "tiktoken": "^1.0.18",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -3365,6 +3366,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tiktoken": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.18.tgz",
+      "integrity": "sha512-DXJesdYwmBHtkmz1sji+UMZ4AOEE8F7Uw/PS/uy0XfkKOzZC4vXkYXHMYyDT+grdflvF4bggtPt9cYaqOMslBw==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -70,10 +70,40 @@
             "default": "plain",
             "description": "🎨 \n Output format style"
           },
+          "repomix.output.parsableStyle": {
+            "order": 3,
+            "type": "boolean",
+            "default": false,
+            "description": "✂️ \n - Ensures output strictly follows the specification of the chosen format. \n - Provides properly escaped XML output with fast-xml-parser.\n - Dynamically adjusts markdown code block delimiters to avoid content conflicts. \n - Note that this option can increase token count."
+          },
+          "repomix.output.headerText": {
+            "order": 4,
+            "type": "string",
+            "default": "",
+            "description": "📝\n Add a header text to the output"
+          },
           "repomix.output.fileSummary": {
+            "order": 5,
             "type": "boolean",
             "default": true,
             "description": "➕📝\n Include file summary in output"
+          },
+          "repomix.output.removeEmptyLines": {
+            "order": 6,
+            "type": "boolean",
+            "default": false,
+            "description": "🧹 \n Remove empty lines from code"
+          },
+          "repomix.output.includeEmptyDirectories": {
+            "order": 7,
+            "type": "boolean",
+            "default": false,
+            "description": "🧹 \n Include empty directories in output"
+          },
+          "repomix.output.instructionFilePath": {
+            "type": "string",
+            "default": "",
+            "description": "🫡\n Path to a file containing detailed custom instructions "
           },
           "repomix.output.directoryStructure": {
             "type": "boolean",
@@ -84,11 +114,6 @@
             "type": "boolean",
             "default": false,
             "description": "💬 ❌  \n Remove comments from code"
-          },
-          "repomix.output.removeEmptyLines": {
-            "type": "boolean",
-            "default": false,
-            "description": "🧹 \n Remove empty lines from code"
           },
           "repomix.output.copyToClipboard": {
             "type": "boolean",
@@ -159,6 +184,26 @@
             "description": "🔒 \n Enable security check during processing"
           }
         }
+      },
+      {
+        "title": "Token Count",
+        "order": 6,
+        "type": "object",
+        "properties": {
+          "repomix.tokenCount.encoding": {
+            "type": "string",
+            "enum": [
+              "o200k_base",
+              "cl100k_base",
+              "p50k_edit",
+              "p50k_base",
+              "r50k_base",
+              "gpt2"
+            ],
+            "default": "o200k_base",
+            "description": "🔢 \n Token count encoding"
+          }
+        }
       }
     ],
     "commands": [
@@ -222,6 +267,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
+    "tiktoken": "^1.0.18",
     "zod": "^3.24.1"
   }
 }

--- a/src/commands/runRepomix.ts
+++ b/src/commands/runRepomix.ts
@@ -65,6 +65,7 @@ export async function runRepomix(
 
     if (stderr) {
       logger.both.error('stderr: \n', stderr);
+      throw new Error(stderr);
     }
 
     const tmpFilePath = path.join(tempDir, config.targetPathRelative.split('/').join('_'));

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -118,6 +118,11 @@ export function mergeConfigs(
       ...configFromRepomixRunnerVscode.security,
       ...configFromRepomixFile?.security,
     },
+    tokenCount: {
+      ...baseConfig.tokenCount,
+      ...configFromRepomixRunnerVscode.tokenCount,
+      ...configFromRepomixFile?.tokenCount,
+    },
   };
 
   return mergedConfigSchema.parse(mergedConfig);

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -1,3 +1,4 @@
+import type { TiktokenEncoding } from 'tiktoken';
 import { z } from 'zod';
 
 // Output style enum
@@ -16,6 +17,9 @@ export const repomixConfigBaseSchema = z.object({
     .object({
       filePath: z.string().optional(),
       style: repomixOutputStyleSchema.optional(),
+      parsableStyle: z.boolean().optional(),
+      headerText: z.string().optional(),
+      instructionFilePath: z.string().optional(),
       fileSummary: z.boolean().optional(),
       directoryStructure: z.boolean().optional(),
       removeComments: z.boolean().optional(),
@@ -23,6 +27,7 @@ export const repomixConfigBaseSchema = z.object({
       topFilesLength: z.number().optional(),
       showLineNumbers: z.boolean().optional(),
       copyToClipboard: z.boolean().optional(),
+      includeEmptyDirectories: z.boolean().optional(),
     })
     .optional(),
   include: z.array(z.string()).optional(),
@@ -38,6 +43,11 @@ export const repomixConfigBaseSchema = z.object({
       enableSecurityCheck: z.boolean().optional(),
     })
     .optional(),
+  tokenCount: z
+    .object({
+      encoding: z.string().optional(),
+    })
+    .optional(),
 });
 
 // Default config schema (avec valeurs par défaut)
@@ -46,6 +56,9 @@ export const repomixConfigDefaultSchema = z.object({
     .object({
       filePath: z.string().default(defaultFilePathMap.plain),
       style: repomixOutputStyleSchema.default('plain'),
+      parsableStyle: z.boolean().default(false),
+      headerText: z.string().default(''),
+      instructionFilePath: z.string().default(''),
       fileSummary: z.boolean().default(true),
       directoryStructure: z.boolean().default(true),
       removeComments: z.boolean().default(false),
@@ -53,6 +66,7 @@ export const repomixConfigDefaultSchema = z.object({
       topFilesLength: z.number().default(5),
       showLineNumbers: z.boolean().default(false),
       copyToClipboard: z.boolean().default(false),
+      includeEmptyDirectories: z.boolean().default(false),
     })
     .default({}),
   include: z.array(z.string()).default([]),
@@ -66,6 +80,14 @@ export const repomixConfigDefaultSchema = z.object({
   security: z
     .object({
       enableSecurityCheck: z.boolean().default(true),
+    })
+    .default({}),
+  tokenCount: z
+    .object({
+      encoding: z
+        .string()
+        .default('o200k_base')
+        .transform(val => val as TiktokenEncoding),
     })
     .default({}),
 });

--- a/src/core/cli/cliFlagsBuilder.ts
+++ b/src/core/cli/cliFlagsBuilder.ts
@@ -6,8 +6,9 @@ export const cliFlags = {
   output: {
     filePath: '--output',
     style: '--style',
-    headerText: null, // MEMO no flag yet for this config in repomix ?
-    instructionFilePath: null, // MEMO no flag yet for this config in repomix ?
+    parsableStyle: '--parsable-style',
+    headerText: '--header-text',
+    instructionFilePath: '--instruction-file-path',
     fileSummary: '--no-file-summary',
     directoryStructure: '--no-directory-structure',
     removeComments: '--remove-comments',
@@ -15,19 +16,19 @@ export const cliFlags = {
     showLineNumbers: '--output-show-line-numbers',
     copyToClipboard: '--copy',
     topFilesLength: '--top-files-len',
-    includeEmptyDirectories: null, // MEMO no flag yet for this config in repomix ?
+    includeEmptyDirectories: '--include-empty-directories',
   },
   include: '--include',
   ignore: {
-    useGitignore: null, // MEMO no flag yet for this config in repomix ?
-    useDefaultPatterns: null, // MEMO no flag yet for this config in repomix ?
+    useGitignore: '--no-gitignore',
+    useDefaultPatterns: '--no-default-patterns',
     customPatterns: '--ignore',
   },
   security: {
     enableSecurityCheck: '--no-security-check',
   },
   tokenCount: {
-    encoding: null, // MEMO no flag yet for this config in repomix ?
+    encoding: '--token-count-encoding',
   },
 } as const;
 
@@ -42,6 +43,18 @@ export function cliFlagsBuilder(config: MergedConfig, flags = cliFlags): string 
   }
   if (config.output.style) {
     outputFlags.push(`${flags.output.style} ${config.output.style}`);
+  }
+  if (config.output.parsableStyle) {
+    outputFlags.push(flags.output.parsableStyle);
+  }
+  if (config.output.headerText) {
+    outputFlags.push(`${flags.output.headerText} "${config.output.headerText}"`);
+  }
+  if (config.output.instructionFilePath) {
+    outputFlags.push(`${flags.output.instructionFilePath} "${config.output.instructionFilePath}"`);
+  }
+  if (config.output.includeEmptyDirectories) {
+    outputFlags.push(flags.output.includeEmptyDirectories);
   }
   if (!config.output.fileSummary) {
     outputFlags.push(flags.output.fileSummary);
@@ -74,9 +87,19 @@ export function cliFlagsBuilder(config: MergedConfig, flags = cliFlags): string 
   if (config.ignore.customPatterns.length > 0) {
     outputFlags.push(`${flags.ignore.customPatterns} "${config.ignore.customPatterns.join(',')}"`);
   }
+  if (!config.ignore.useGitignore) {
+    outputFlags.push(flags.ignore.useGitignore);
+  }
+  if (!config.ignore.useDefaultPatterns) {
+    outputFlags.push(flags.ignore.useDefaultPatterns);
+  }
   // Security
   if (!config.security.enableSecurityCheck) {
     outputFlags.push(flags.security.enableSecurityCheck);
+  }
+  // Token Count
+  if (config.tokenCount.encoding) {
+    outputFlags.push(`${flags.tokenCount.encoding} ${config.tokenCount.encoding}`);
   }
 
   return outputFlags.join(' ');

--- a/src/test/commands/runRepomix.test.ts
+++ b/src/test/commands/runRepomix.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import { runRepomix } from '../../commands/runRepomix';
 import { type ChildProcess, type ExecOptions } from 'child_process';
 import { execPromisify } from '../../shared/execPromisify';
+import { MergedConfig } from '../../config/configSchema';
 
 type PromiseWithChild<T> = Promise<T> & { child: ChildProcess };
 
@@ -12,7 +13,7 @@ suite('runRepomix', () => {
     return promise as PromiseWithChild<{ stdout: string; stderr: string }>;
   }) as unknown as typeof execPromisify;
 
-  const baseTestConfig = {
+  const baseTestConfig: MergedConfig = {
     targetDir: '/fake/target',
     targetDirBasename: 'target',
     targetPathRelative: 'target',
@@ -24,6 +25,9 @@ suite('runRepomix', () => {
     output: {
       filePath: '/fake/output.txt',
       style: 'plain' as const,
+      parsableStyle: false,
+      headerText: '',
+      instructionFilePath: '',
       fileSummary: true,
       directoryStructure: true,
       removeComments: false,
@@ -31,10 +35,12 @@ suite('runRepomix', () => {
       topFilesLength: 5,
       showLineNumbers: false,
       copyToClipboard: false,
+      includeEmptyDirectories: false,
     },
     include: [],
     ignore: { useGitignore: true, useDefaultPatterns: true, customPatterns: [] },
     security: { enableSecurityCheck: true },
+    tokenCount: { encoding: 'o200k_base' },
   };
 
   test('should call copyToClipboard when config.output.copyToClipboard is true and config.runner.copyMode is file', async () => {

--- a/src/test/config/configLoader.test.ts
+++ b/src/test/config/configLoader.test.ts
@@ -111,6 +111,9 @@ suite('configLoader', () => {
         output: {
           filePath: 'output.txt',
           style: 'plain',
+          parsableStyle: false,
+          headerText: '',
+          instructionFilePath: '',
           fileSummary: true,
           directoryStructure: true,
           removeComments: false,
@@ -118,6 +121,7 @@ suite('configLoader', () => {
           topFilesLength: 5,
           showLineNumbers: true,
           copyToClipboard: false,
+          includeEmptyDirectories: false,
         },
         include: ['**/*'],
         ignore: {
@@ -127,6 +131,9 @@ suite('configLoader', () => {
         },
         security: {
           enableSecurityCheck: true,
+        },
+        tokenCount: {
+          encoding: 'o200k_base',
         },
       };
       // stub the vscode settings
@@ -233,6 +240,9 @@ suite('configLoader', () => {
         output: {
           filePath: 'output.txt',
           style: 'xml',
+          parsableStyle: false,
+          headerText: '',
+          instructionFilePath: '',
           fileSummary: true,
           directoryStructure: true,
           removeComments: false,
@@ -240,6 +250,7 @@ suite('configLoader', () => {
           topFilesLength: 10,
           showLineNumbers: true,
           copyToClipboard: false,
+          includeEmptyDirectories: false,
         },
         include: ['**/*'],
         ignore: {
@@ -250,12 +261,26 @@ suite('configLoader', () => {
         security: {
           enableSecurityCheck: true,
         },
+        tokenCount: {
+          encoding: 'o200k_base',
+        },
       };
 
       const fileConfig: RepomixConfigFile = {
         output: {
           style: 'plain',
           filePath: 'custom.txt',
+          headerText: 'coucou',
+          parsableStyle: true,
+          instructionFilePath: 'instruction.txt',
+          includeEmptyDirectories: true,
+        },
+        ignore: {
+          useGitignore: false,
+          useDefaultPatterns: false,
+        },
+        tokenCount: {
+          encoding: 'gpt2',
         },
       };
 
@@ -264,6 +289,13 @@ suite('configLoader', () => {
       assert.ok(merged.targetDir === targetDir);
       assert.ok(merged.targetDirBasename === path.relative(testCwd, targetDir));
       assert.ok(merged.output.style === 'plain'); // xml from vscode settings is overridden by plain from repomix.config.json
+      assert.ok(merged.output.headerText === 'coucou');
+      assert.ok(merged.output.parsableStyle === true);
+      assert.ok(merged.output.instructionFilePath === 'instruction.txt');
+      assert.ok(merged.output.includeEmptyDirectories === true);
+      assert.ok(merged.ignore.useGitignore === false);
+      assert.ok(merged.ignore.useDefaultPatterns === false);
+      assert.ok(merged.tokenCount.encoding === 'gpt2');
     });
 
     /**

--- a/src/test/core/cli/cliFlagsBuilder.test.ts
+++ b/src/test/core/cli/cliFlagsBuilder.test.ts
@@ -54,6 +54,71 @@ suite('CliFlagsBuilder', () => {
     assert.ok(flags.includes('--style markdown'));
   });
 
+  test('should add "--parsable-style" flag when output.parsableStyle is true', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      output: { ...baseConfig.output, parsableStyle: true },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--parsable-style'));
+  });
+
+  test('should add "--header-text" flag when output.headerText is specified', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      output: { ...baseConfig.output, headerText: 'coucou' },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--header-text "coucou"'));
+  });
+
+  test('should add "--instruction-file-path" flag when output.instructionFilePath is specified', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      output: { ...baseConfig.output, instructionFilePath: 'instruction.txt' },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--instruction-file-path "instruction.txt"'));
+  });
+
+  test('should add "--include-empty-directories" flag when output.includeEmptyDirectories is true', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      output: { ...baseConfig.output, includeEmptyDirectories: true },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--include-empty-directories'));
+  });
+
+  test('should add "--no-gitignore" flag when ignore.useGitignore is false', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      ignore: { ...baseConfig.ignore, useGitignore: false },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--no-gitignore'));
+  });
+
+  test('should add "--no-default-patterns" flag when ignore.useDefaultPatterns is false', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      ignore: { ...baseConfig.ignore, useDefaultPatterns: false },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--no-default-patterns'));
+  });
+
+  test('shouldf add "--token-count-encoding" flag when config.tokenCountEncoding is specified', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      tokenCount: {
+        encoding: 'o200k_base',
+      },
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(flags.includes('--token-count-encoding o200k_base'));
+  });
+
   test('should add "--no-file-summary" flag when output.fileSummary is false', () => {
     const config: MergedConfig = {
       ...baseConfig,


### PR DESCRIPTION
### Changed

- Add new supported Repomix config options
  - output.parsableStyle
  - output.headerText
  - output.instructionFilePath
  - output.includeEmptyDirectories
  - ignore.useGitignore
  - tokenCount.encoding