### PR TITLE
normalize backslashes for windows compatibility

### DIFF
--- a/src/core/cli/cliFlagsBuilder.ts
+++ b/src/core/cli/cliFlagsBuilder.ts
@@ -85,7 +85,9 @@ export function cliFlagsBuilder(config: MergedConfig, flags = cliFlags): string 
   }
   // Include
   if (config.include.length > 0) {
-    outputFlags.push(`${flags.include} "${config.include.join(',')}"`);
+    // Normalize Windows paths: replace backslashes with normal slashes
+    const normalizedPaths = config.include.map(path => path.replace(/\\/g, '/'));
+    outputFlags.push(`${flags.include} "${normalizedPaths.join(',')}"`);
   }
   // Ignore
   if (config.ignore.customPatterns.length > 0) {

--- a/src/test/core/cli/cliFlagsBuilder.test.ts
+++ b/src/test/core/cli/cliFlagsBuilder.test.ts
@@ -280,4 +280,22 @@ suite('CliFlagsBuilder', () => {
     assert.ok(flags.includes('--no-security-check'));
     assert.ok(flags.includes('--compress'));
   });
+
+  test('should normalize Windows paths with backslashes in config.include', () => {
+    const config: MergedConfig = {
+      ...baseConfig,
+      include: [
+        'path\\to\\file.js',
+        'another\\path\\file.ts',
+        '\\root\\path.js',
+        'mixed/path\\with/backslash.js',
+      ],
+    };
+    const flags = cliFlagsBuilder(config);
+    assert.ok(
+      flags.includes(
+        '--include "path/to/file.js,another/path/file.ts,/root/path.js,mixed/path/with/backslash.js"'
+      )
+    );
+  });
 });


### PR DESCRIPTION
Fixed Windows paths by normalizing escaped backslashes (`\\`)  to forward slashes (/) for pattern compatibility.

Related to https://github.com/massdo/repomix-runner/issues/5