### PR TITLE
fix: keep a successful run alive when the command writes to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the "Repomix Runner" extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-09-06
+
+### Fixed
+
+- A successful Repomix run is no longer reported as a failure when the command writes to `stderr`. Anything a healthy run prints there — npm notices, Node deprecation warnings, `npx` download progress — used to abort the run, so the clipboard copy, the success notification and the output cleanup never happened. Real failures are still reported. Affects Run, Run on Selection, Run on Open Files and Run Bundle.
+
+### Thanks
+
+- [@DevGuyRash](https://github.com/DevGuyRash) for reporting [#40](https://github.com/MassDo/repomix-runner/issues/40) with an exact diagnosis and the fix.
+
 ## [0.5.1] - 2026-09-06
 
 ### Changed

--- a/src/commands/runRepomix.ts
+++ b/src/commands/runRepomix.ts
@@ -79,9 +79,11 @@ export async function runRepomix(deps: RunRepomixDeps = defaultRunRepomixDeps): 
       logger.both.info('stdout: \n', stdout);
     }
 
+    // A successful run can still write to stderr (npm notices, node warnings, npx
+    // download progress). execPromisify already rejects on a non-zero exit code,
+    // so stderr alone must not fail the run. See issue #40.
     if (stderr) {
-      logger.both.error('stderr: \n', stderr);
-      throw new Error(stderr);
+      logger.both.warn('stderr: \n', stderr);
     }
 
     const tmpFilePath = path.join(

--- a/src/test/commands/runRepomix.test.ts
+++ b/src/test/commands/runRepomix.test.ts
@@ -9,11 +9,23 @@ import { tempDirManager } from '../../core/files/tempDirManager.js';
 type PromiseWithChild<T> = Promise<T> & { child: ChildProcess };
 
 suite('runRepomix', () => {
-  const mockExecPromisify = ((command: string, options?: ExecOptions) => {
-    const promise = Promise.resolve({ stdout: '', stderr: '' });
-    (promise as PromiseWithChild<{ stdout: string; stderr: string }>).child = {} as ChildProcess;
-    return promise as PromiseWithChild<{ stdout: string; stderr: string }>;
-  }) as unknown as typeof execPromisify;
+  const mockExecPromisifyWith = (stderr: string) =>
+    ((command: string, options?: ExecOptions) => {
+      const promise = Promise.resolve({ stdout: '', stderr });
+      (promise as PromiseWithChild<{ stdout: string; stderr: string }>).child = {} as ChildProcess;
+      return promise as PromiseWithChild<{ stdout: string; stderr: string }>;
+    }) as unknown as typeof execPromisify;
+
+  const mockExecPromisify = mockExecPromisifyWith('');
+
+  const mockExecPromisifyRejecting = (message: string) =>
+    ((command: string, options?: ExecOptions) => {
+      const promise: Promise<{ stdout: string; stderr: string }> = Promise.reject(
+        new Error(message)
+      );
+      (promise as PromiseWithChild<{ stdout: string; stderr: string }>).child = {} as ChildProcess;
+      return promise as PromiseWithChild<{ stdout: string; stderr: string }>;
+    }) as unknown as typeof execPromisify;
 
   const baseTestConfig: MergedConfig = {
     cwd: '/fake/target',
@@ -133,6 +145,125 @@ suite('runRepomix', () => {
       cleanOutputFileArgs[0],
       '/fake/output.txt',
       'cleanOutputFile should be called with correct file path'
+    );
+  });
+
+  test('should complete the run when the command writes to stderr but exits successfully', async () => {
+    // npm writes informational notices to stderr on a successful run, see issue #40
+    const npmNotice = "npm notice run npx\nnpm notice run 'repomix' --version\n";
+
+    // Setup
+    let copyToClipboardCalled = false;
+    let cleanOutputFileCalled = false;
+
+    const mockConfig = {
+      ...baseTestConfig,
+      runner: {
+        ...baseTestConfig.runner,
+        keepOutputFile: false,
+      },
+      output: {
+        ...baseTestConfig.output,
+        copyToClipboard: true,
+      },
+    };
+
+    const mockDeps = {
+      tempDirManager: tempDirManager,
+      getCwd: () => baseTestConfig.cwd,
+      copyToClipboard: () => {
+        copyToClipboardCalled = true;
+        return Promise.resolve();
+      },
+      cleanOutputFile: () => {
+        cleanOutputFileCalled = true;
+        return Promise.resolve();
+      },
+      mergeConfigs: () => Promise.resolve(mockConfig),
+      readRepomixRunnerVscodeConfig: () => mockConfig,
+      readRepomixFileConfig: () => Promise.resolve(),
+      cliFlagsBuilder: () => '',
+      execPromisify: mockExecPromisifyWith(npmNotice),
+      mergeConfigOverride: null,
+    };
+
+    // Execute
+    await runRepomix(mockDeps);
+
+    // Assert
+    assert.strictEqual(
+      copyToClipboardCalled,
+      true,
+      'copyToClipboard should still run when stderr is not empty'
+    );
+    assert.strictEqual(
+      cleanOutputFileCalled,
+      true,
+      'cleanOutputFile should still run when stderr is not empty'
+    );
+  });
+
+  test('should still fail when the command exits with a non-zero status', async () => {
+    // Setup
+    let copyToClipboardCalled = false;
+    let cleanOutputFileCalled = false;
+
+    const mockConfig = {
+      ...baseTestConfig,
+      runner: {
+        ...baseTestConfig.runner,
+        keepOutputFile: false,
+      },
+      output: {
+        ...baseTestConfig.output,
+        copyToClipboard: true,
+      },
+    };
+
+    const makeDeps = (execPromisifyMock: typeof mockExecPromisify) => ({
+      tempDirManager: tempDirManager,
+      getCwd: () => baseTestConfig.cwd,
+      copyToClipboard: () => {
+        copyToClipboardCalled = true;
+        return Promise.resolve();
+      },
+      cleanOutputFile: () => {
+        cleanOutputFileCalled = true;
+        return Promise.resolve();
+      },
+      mergeConfigs: () => Promise.resolve(mockConfig),
+      readRepomixRunnerVscodeConfig: () => mockConfig,
+      readRepomixFileConfig: () => Promise.resolve(),
+      cliFlagsBuilder: () => '',
+      execPromisify: execPromisifyMock,
+      mergeConfigOverride: null,
+    });
+
+    // Execute
+    await assert.rejects(
+      () => runRepomix(makeDeps(mockExecPromisifyRejecting('repomix exited with code 1'))),
+      /repomix exited with code 1/,
+      'runRepomix should reject when the command exits with a non-zero status'
+    );
+
+    // Assert
+    assert.strictEqual(
+      copyToClipboardCalled,
+      false,
+      'copyToClipboard should not run when the command failed'
+    );
+    assert.strictEqual(
+      cleanOutputFileCalled,
+      false,
+      'cleanOutputFile should not run when the command failed'
+    );
+
+    // The run lock must be released so a later run still goes through
+    await runRepomix(makeDeps(mockExecPromisify));
+    assert.strictEqual(
+      copyToClipboardCalled,
+      true,
+      'a later run should still go through after a failure'
     );
   });
 });


### PR DESCRIPTION
Closes #40

## The bug

`runRepomix` threw whenever the child process wrote anything to `stderr`:

```ts
if (stderr) {
  logger.both.error('stderr: \n', stderr);
  throw new Error(stderr);
}
```

`execPromisify` is `promisify(exec)`, which already rejects on a non-zero exit code. The `stderr` check was therefore redundant for real failures, and a false positive for any successful run that prints to `stderr` — npm notices, Node deprecation warnings, `npx -y repomix@latest` download progress when the npx cache expires, proxy or corepack warnings.

The wrong notification was not the real cost. The throw cut the run short, so the clipboard copy (in `file` copy mode), the success notification and the output cleanup never ran. Run Bundle additionally skipped its `lastUsed` update and `saveBundle`, then raised a second error notification. Four commands were affected: Run, Run on Selection, Run on Open Files, Run Bundle.

## The fix

`stderr` is logged as a warning and stays visible. The original rejection from `execPromisify` and the existing `catch` are untouched, so genuine failures, signals and `maxBuffer` overruns keep propagating.

## Tests

Two regressions in `src/test/commands/runRepomix.test.ts`:

- a successful run with a non-empty `stderr` must reach both the clipboard copy and the output cleanup — it pins the domino effect, not merely the absence of an exception;
- a non-zero exit must still reject, run no success step, and release the module-level `isRunning` lock so a later run still goes through.

## Verification

- `npm test`: **97 passing**, exit 0 (95 before this work). `pretest` covers `compile-tests`, `check-types`, `lint` and the build.
- The first regression was run against the unpatched source and fails there on `Error: npm notice run npx`, so it fails for the right reason.
- Environment: VS Code 1.96.2, macOS arm64.

## Out of scope, noted while auditing

- `exec` has a 1 MB default `maxBuffer`; a large repo with a high `--top-files-len` can exceed it. Unrelated to #40.
- `showTempNotification` is called without `await` at `src/commands/runRepomix.ts:72` and rethrows, so a real repomix failure leaves an unhandled rejection. To be handled separately.

Reported by @DevGuyRash, with an exact diagnosis and the proposed fix.
